### PR TITLE
Fix handling of TF_USE_ACCESS_IP env var

### DIFF
--- a/tofu.py
+++ b/tofu.py
@@ -263,7 +263,7 @@ class TerraformInventory(object):
       hostrecord['floating_ips'] = self.get_floating_ip_associations(
                                               instance_id=instance_id )
 
-      if use_access_ip == True:
+      if use_access_ip:
         hostrecord['ansible_host'] = attributes.access_ip_v4
       else:
         hostrecord['ansible_host'] = hostrecord['floating_ips'][0].address


### PR DESCRIPTION
Env var TF_USE_ACCESS_IP was effectively ignored. Now if it is set to any non-empty string, it is considered to be enabled.